### PR TITLE
Add name change bar to editor

### DIFF
--- a/addons/btree/Editor/editor.tscn
+++ b/addons/btree/Editor/editor.tscn
@@ -12,13 +12,13 @@ __meta__ = {
 }
 
 [node name="group" type="HBoxContainer" parent="."]
-margin_right = 640.0
+margin_right = 1024.0
 margin_bottom = 20.0
 alignment = 2
 
 [node name="create" type="MenuButton" parent="group"]
-margin_left = 439.0
-margin_right = 492.0
+margin_left = 823.0
+margin_right = 876.0
 margin_bottom = 20.0
 text = "Create"
 items = [ "Task", null, 0, false, false, 1, 0, null, "", false, "Selector", null, 0, false, false, 3, 0, null, "", false, "Sequence", null, 0, false, false, 2, 0, null, "", false, "Priority Selector", null, 0, false, false, 4, 0, null, "", false, "Priority Condition", null, 0, false, false, 5, 0, null, "", false, "Paralel", null, 0, false, false, 6, 0, null, "", false, "Mute", null, 0, false, false, 7, 0, null, "", false, "Repeat", null, 0, false, false, 8, 0, null, "", false, "While Node", null, 0, false, false, 9, 0, null, "", false, "Wait Node", null, 0, false, false, 10, 0, null, "", false, "Race Node", null, 0, false, false, 11, 0, null, "", false, "Random Selector", null, 0, false, false, 12, 0, null, "", false, "Random Sequence", null, 0, false, false, 13, 0, null, "", false, "Inverter", null, 0, false, false, 14, 0, null, "", false, "Random Repeat", null, 0, false, false, 15, 0, null, "", false, "Random Wait", null, 0, false, false, 16, 0, null, "", false ]
@@ -27,27 +27,27 @@ graph_path = NodePath("../../graph")
 hint_path = NodePath("../../footer/hint")
 
 [node name="save" type="Button" parent="group"]
-margin_left = 496.0
-margin_right = 537.0
+margin_left = 880.0
+margin_right = 921.0
 margin_bottom = 20.0
 text = "Save"
 
 [node name="debug" type="Button" parent="group"]
-margin_left = 541.0
-margin_right = 594.0
+margin_left = 925.0
+margin_right = 978.0
 margin_bottom = 20.0
 text = "Debug"
 
 [node name="help" type="Button" parent="group"]
-margin_left = 598.0
-margin_right = 640.0
+margin_left = 982.0
+margin_right = 1024.0
 margin_bottom = 20.0
 text = "Help"
 
 [node name="graph" type="GraphEdit" parent="."]
 margin_top = 24.0
-margin_right = 640.0
-margin_bottom = 332.0
+margin_right = 1024.0
+margin_bottom = 572.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 right_disconnects = true
@@ -60,18 +60,18 @@ create_path = NodePath("../group/create")
 anchor_top = 0.5
 anchor_bottom = 0.5
 margin_left = 320.0
-margin_top = -26.0
+margin_top = -146.0
 margin_right = 380.0
-margin_bottom = 34.0
+margin_bottom = -86.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
 title = "root"
 
 [node name="footer" type="HBoxContainer" parent="."]
-margin_top = 336.0
-margin_right = 640.0
-margin_bottom = 360.0
+margin_top = 576.0
+margin_right = 1024.0
+margin_bottom = 600.0
 alignment = 1
 __meta__ = {
 "_edit_use_anchors_": false
@@ -79,14 +79,40 @@ __meta__ = {
 
 [node name="hint" type="Label" parent="footer"]
 margin_top = 5.0
-margin_right = 292.0
+margin_right = 326.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
 
+[node name="name" type="HBoxContainer" parent="footer"]
+margin_left = 330.0
+margin_right = 676.0
+margin_bottom = 24.0
+
+[node name="Label" type="Label" parent="footer/name"]
+margin_top = 5.0
+margin_right = 80.0
+margin_bottom = 19.0
+text = "Node Name:"
+
+[node name="name_bar" type="LineEdit" parent="footer/name"]
+margin_left = 84.0
+margin_right = 284.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 200, 0 )
+caret_blink = true
+caret_blink_speed = 0.5
+
+[node name="change_name" type="Button" parent="footer/name"]
+margin_left = 288.0
+margin_right = 346.0
+margin_bottom = 24.0
+hint_tooltip = "ctrl + shift + LEFT"
+text = "Change"
+
 [node name="search" type="HBoxContainer" parent="footer"]
-margin_left = 296.0
-margin_right = 640.0
+margin_left = 680.0
+margin_right = 1024.0
 margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="footer/search"]
@@ -124,6 +150,8 @@ text = ">"
 [connection signal="gui_input" from="graph" to="graph" method="gui_input"]
 [connection signal="node_selected" from="graph" to="graph" method="node_selected"]
 [connection signal="popup_request" from="graph" to="graph" method="popup_request"]
+[connection signal="text_changed" from="footer/name/name_bar" to="graph" method="_on_name_bar_text_changed"]
+[connection signal="pressed" from="footer/name/change_name" to="graph" method="_on_change_name_pressed"]
 [connection signal="text_changed" from="footer/search/search_bar" to="graph" method="_on_search_bar_text_changed"]
 [connection signal="pressed" from="footer/search/prev" to="graph" method="_on_prev_pressed"]
 [connection signal="pressed" from="footer/search/next" to="graph" method="_on_next_pressed"]

--- a/addons/btree/Editor/graph.gd
+++ b/addons/btree/Editor/graph.gd
@@ -867,6 +867,8 @@ func rec_populate(root, nodes:Array):
 
 func node_selected(node):
 	selected = node
+	name_text = selected.title
+	get_parent().get_node('footer/name/name_bar').text = name_text
 	return
 
 func focus_selected():
@@ -879,6 +881,7 @@ func focus_selected():
 
 var tindex = 0
 var search_text = ""
+var name_text = ""
 
 func _on_search_bar_text_changed(new_text):
 	tindex = 0
@@ -887,6 +890,14 @@ func _on_search_bar_text_changed(new_text):
 	if  not tpairs.empty():
 		var si = tpairs[tindex][1]
 		scroll_offset = si.offset * zoom - ((rect_size / 2) - (si.rect_size / 2))
+	return
+
+func _on_change_name_pressed():
+	if selected is Node:
+		selected.title = name_text
+		selected.name = name_text
+func _on_name_bar_text_changed(new_text):
+	name_text = new_text
 	return
 
 func _on_next_pressed():


### PR DESCRIPTION
This change just adds a small bar in the bottom right next to the search bar that allows users to name their nodes

![image](https://user-images.githubusercontent.com/34534492/115132828-10ce2680-a047-11eb-8234-badf00792e32.png)

It updates when you change selected nodes.

There was a similar pull request that I closed accidentally