### PR TITLE
Fixed issue with behavior tree nodes not saving on tab swap

### DIFF
--- a/addons/btree/init.gd
+++ b/addons/btree/init.gd
@@ -11,8 +11,12 @@ func selection_changed():
 	if  not dock:
 		return
 	var tree_editor = dock.get_node("editor/graph")
-	tree_editor.clear_editor()
+	
 	var selection = get_editor_interface().get_selection().get_selected_nodes()
+	var graph = dock.get_node("editor/graph")
+	if graph:
+		graph._on_save_pressed()
+	tree_editor.clear_editor()
 	if  not selection:
 		tree_editor.clear_data()
 		dock.halt("Please select a BTREE node")


### PR DESCRIPTION
Fixed issue where swapping tabs would not save behavior tree. Fixes #55 

![HADs0YbKE9](https://user-images.githubusercontent.com/12516772/132134533-45760d17-1e1b-4b8c-9a49-29c4d12ff201.gif)

readding... accidentally deleted 